### PR TITLE
Fix tooltip color for GTK 3 applications.

### DIFF
--- a/gtk-3.0/_colors.scss
+++ b/gtk-3.0/_colors.scss
@@ -45,6 +45,10 @@ $selected_bg_color: #00BCD4;
 $secondary_selected_bg_color: #00E5FF;
 $accent_bg_color: #FF4081;
 
+// Tooltips colors
+$tooltip_color: #FFFFFF;
+$tooltip_background_color: if($variant == 'light', #00BCD4, #455A64);
+
 // Misc colors
 $track_color: gtkalpha(currentColor, $lower_opacity);
 $borders_color: if($variant == 'light', scale-alpha(#000000, 0.1), scale-alpha(#000000, 0.2));

--- a/gtk-3.0/_common.scss
+++ b/gtk-3.0/_common.scss
@@ -2890,7 +2890,7 @@ tooltip {
   &.background {
     // background-color needs to be set this way otherwise it gets drawn twice
     // see https://bugzilla.gnome.org/show_bug.cgi?id=736155 for details.
-    background-color: scale-alpha($base_color, $higher_opacity);
+    background-color: scale-alpha($tooltip_background_color, $higher_opacity);
   }
 
   // @extend %osd;
@@ -2910,7 +2910,7 @@ tooltip {
   * { // Yeah this is ugly
     padding: 0;
     background-color: transparent;
-    color: inherit;
+    color: $tooltip_color;
   }
 }
 

--- a/gtk-3.0/gtk-dark.css
+++ b/gtk-3.0/gtk-dark.css
@@ -2425,7 +2425,7 @@ tooltip {
   tooltip * {
     padding: 0;
     background-color: transparent;
-    color: inherit; }
+    color: #FFFFFF; }
 
 /*****************
  * Color Chooser *

--- a/gtk-3.0/gtk.css
+++ b/gtk-3.0/gtk.css
@@ -2416,7 +2416,7 @@ tooltip {
   border-radius: 2px;
   box-shadow: none; }
   tooltip.background {
-    background-color: rgba(255, 255, 255, 0.9); }
+    background-color: rgba(0, 188, 212, 0.9); }
   tooltip decoration {
     background-color: transparent; }
   tooltip label {
@@ -2425,7 +2425,7 @@ tooltip {
   tooltip * {
     padding: 0;
     background-color: transparent;
-    color: inherit; }
+    color: #FFFFFF; }
 
 /*****************
  * Color Chooser *


### PR DESCRIPTION
The story is, some GTK 3 application has it's own Tooltip (The little message will be displayed when your mouse hover over) font color (usually white) which is not unchangeable by using Gnome's style files.

It cause some problems because the the Tooltip background can also be white. When that happens, it will be like:

![](https://cloud.githubusercontent.com/assets/4244947/16459464/6dfe7368-3e55-11e6-8d1e-fef6bc91c11b.png)

To get around it, I changed the Tooltip background to

![](https://cloud.githubusercontent.com/assets/4244947/16459481/7d7f9bfa-3e55-11e6-8e83-f8a633559e21.png)

Dark theme remain unchanged:

![](https://cloud.githubusercontent.com/assets/4244947/16459503/857260c2-3e55-11e6-98d5-1b5169bbb3b2.png)

Hope it will help someone :)