### PR TITLE
Add Copr repo to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Installation
 ------------
 Arch Linux users can install from the [AUR package](https://aur.archlinux.org/packages/flatplat-theme) maintained by @cthbleachbit.
 
+Fedora and EPEL users can also install from a [Copr repository](https://copr.fedorainfracloud.org/coprs/tcg/themes/).
+
 ### Manual Installation
 1. Open the terminal and run the following commands:
 


### PR DESCRIPTION
Since there seems to be only an AUR package (at least judging from the README), I just created an RPM to ease the installation and upgrade for Fedora and EPEL users. This PR simply mentions it in the README alongside the AUR one.