### PR TITLE
Install: Allow GNOME Shell version override

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -3,10 +3,12 @@
 repodir=$(cd $(dirname $0) && pwd)
 srcdir=${repodir}/src
 
-if type -p gnome-shell > /dev/null ; then
-  gnomever=$(gnome-shell --version | cut -d ' ' -f 3 | cut -d . -f -2)
-else
-  gnomever=3.18
+if test -z "$gnomever" ; then
+  if type -p gnome-shell > /dev/null ; then
+    gnomever=$(gnome-shell --version | cut -d ' ' -f 3 | cut -d . -f -2)
+  else
+    gnomever=3.18
+  fi
 fi
 
 echo


### PR DESCRIPTION
This allows overriding shell version in installer via the "gnomever"
environment variable. This is needed when installing in developer builds
of GNOME, where the result of calling "gnome-shell --version" may not
match the versions available in this repository, thus failing to build
shell theme.